### PR TITLE
Support a(x) syntax for radish/457

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -32,7 +32,14 @@ def test_parser(infix, expected):
     ('a or b', ['c'], False),
     ('not a', ['b'], True),
     ('not a', ['a'], False),
-    ('not a', [], True)
+    ('not a', [], True),
+    ('not a(x)', [], True),
+    ('not a(x)', ['a(x)'], False),
+    ('a(x) or b', ['a(x)'], True),
+    ('a(x) or b', ['b'], True),
+    ('a(x) or b', [''], False),
+    ('a(x,y) or b', [''], False),
+    ('sometag(someValue,y) or b', [''], False)
 ])
 def test_basic_evaluation(infix, values, expected):
     """Test basic tag expression evaluation"""
@@ -60,6 +67,8 @@ def test_complex_evaluation(infix, values, expected):
     ('a or b', ['a', 'b'], True),
     ('a or b', ['a'], True),
     ('not a', ['b'], True),
+    ('sometag(someValue,y) or b', ['b'], True),
+    ('sometag(someValue,y) or b', ['sometag(someValue,y)'], True)
 ])
 def test_direct_evaluation(infix, values, expected):
     """Test direct evaluation of an infix against some values"""


### PR DESCRIPTION
to support https://github.com/radish-bdd/radish/pull/457

This will treat a(x,y) as an individual token by replacing them with a unique identifier, processing like normal, then reinjecting the token value before outputting. 